### PR TITLE
Update comment.rb

### DIFF
--- a/lib/comment.rb
+++ b/lib/comment.rb
@@ -5,7 +5,7 @@ class Comment
   
   def initialize(context, start_chars, end_chars, disable_indent)
     @context, @start_chars, @end_chars = context, start_chars, end_chars
-    @disable_indent = (disable_indent.downcase == 'yes')
+    @disable_indent = (disable_indent && disable_indent.downcase == 'yes')
   end
 
   def Comment.from_env(context)

--- a/lib/comment.rb
+++ b/lib/comment.rb
@@ -5,7 +5,7 @@ class Comment
   
   def initialize(context, start_chars, end_chars, disable_indent)
     @context, @start_chars, @end_chars = context, start_chars, end_chars
-    @disable_indent = (disable_indent == 'YES')
+    @disable_indent = (disable_indent.downcase == 'yes')
   end
 
   def Comment.from_env(context)
@@ -213,10 +213,10 @@ class LineComment < Comment
     if lines.empty?
       output = @start_chars
     else
-      # Prepend the comment beginning to each line, Retain existing indent (that's the index/regexp thing)!
+      # Prepend the comment beginning to each line, Retain existing indent if required (that's the index/regexp thing)!
       lines.each do |l|
         next unless l
-        index = l.index(/\S/)
+        index = @disable_indent ? 0 : l.index(/\S/)
         if index
           output << "#{l[0...index]}#{@start_chars}#{l[index..-1]}#{newline}"
         else


### PR DESCRIPTION
It looks like source.ruble/lib/comment.rb is missing some code.

Change line 218 from:
index = l.index(/\S/)

to:
index = @disable_indent ? 0 : l.index(/\S/)

Then in your language bundle (like ruby.ruble/bundle.rb or js.ruble/bundle.rb), in the block: 
env 'source.ruby' do |e|

add:
e['TM_COMMENT_DISABLE_INDENT'] = 'YES'

Personally, to avoid any problems with the wrong value being passed in for TM_COMMENT_DISABLE_INDENT, I would also change line 8 of source.ruble/lib/comment.rb from:
    @disable_indent = (disable_indent == 'YES')

to:
    @disable_indent = (disable_indent.downcase == 'yes')
